### PR TITLE
Tâche 3 : Production de la documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+docs
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpdocumentor/phpdocumentor": "2.*"
+    }
+}


### PR DESCRIPTION
phpDocumentor est maintenant installable grâce à php composer, pour générer la documentation il suffit d'installer les dépendances : 
`composer update`
et de lancer phpDocumentor : 
`php ./vendor/bin/phpdoc -d app -t ./docs/`