### PR TITLE
Tâche 4 : Gestion du refus de certains frais hors forfait

### DIFF
--- a/app/controleurs/c_suivrePaiement.php
+++ b/app/controleurs/c_suivrePaiement.php
@@ -13,6 +13,8 @@
 $idVisiteur = filter_input(INPUT_GET, 'visiteur', FILTER_SANITIZE_STRING);
 $leMois = filter_input(INPUT_GET, 'mois', FILTER_SANITIZE_STRING);
 $action = filter_input(INPUT_GET, 'action', FILTER_SANITIZE_STRING);
+$fraisHorsForfait = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_STRING);
+
 
 $lesVisiteurs = $pdo->getLesVisiteurs();
 $lesMois = $pdo->getTousLesMoisDisponibles();
@@ -35,6 +37,9 @@ case 'mettreEnPaiement':
     break;
 case 'rembourser':
     $pdo->majEtatFicheFrais($idVisiteur, $leMois, 'RB');
+    break;
+case 'refuser':
+    $pdo->refuserFraisHorsForfait($idVisiteur, $leMois, $fraisHorsForfait);
     break;
 }
 $lesFraisForfait = $pdo->getLesFraisForfait($idVisiteur, $leMois);

--- a/app/vues/v_suivrePaiement.php
+++ b/app/vues/v_suivrePaiement.php
@@ -60,16 +60,20 @@ namespace ns;
             <th class="date">Date</th>
             <th class="libelle">Libellé</th>
             <th class='montant'>Montant</th>
+            <th class="action"></th>
         </tr>
         <?php
         foreach ($lesFraisHorsForfait as $unFraisHorsForfait) {
             $date = $unFraisHorsForfait['date'];
             $libelle = htmlspecialchars($unFraisHorsForfait['libelle']);
-            $montant = $unFraisHorsForfait['montant']; ?>
+            $montant = $unFraisHorsForfait['montant'];
+            $id = $unFraisHorsForfait['id']; ?>
             <tr>
                 <td><?php echo $date ?></td>
                 <td><?php echo $libelle ?></td>
                 <td><?php echo $montant ?></td>
+                <td><a href="./?uc=suivrepaiement&visiteur=<?php echo($idVisiteur);?>&mois=<?php echo($leMois);?>&id=<?php echo $id ?>&action=refuser"
+                       onclick="return confirm('Voulez-vous vraiment refuser ce frais?');">Refuser ce frais</a></td>
             </tr>
             <?php
         }


### PR DESCRIPTION
Possibilités pour les comptables de refuser un frais hors forfait sur la page de validation des fiches de frais.
Le frais refusé est reporté à la fiche de frais du mois suivant (qui est crée si elle n'existe pas déjà) et le texte "REFUSÉ" est ajouté à son libellé.