### PR TITLE
Tâche 5 : Securisation des mots de passe stockés

### DIFF
--- a/app/includes/class.pdogsb.inc.php
+++ b/app/includes/class.pdogsb.inc.php
@@ -104,23 +104,32 @@ class PdoGsb
         if ($type == 'visiteur') {
             $requetePrepare = PdoGsb::$monPdo->prepare(
                 'SELECT visiteur.id AS id, visiteur.nom AS nom, '
-                . 'visiteur.prenom AS prenom '
+                . 'visiteur.prenom AS prenom, '
+                . 'visiteur.mdp AS mdp '
                 . 'FROM visiteur '
-                . 'WHERE visiteur.login = :unLogin AND visiteur.mdp = :unMdp'
+                . 'WHERE visiteur.login = :unLogin'
             );
         } elseif ($type == 'comptable') {
             $requetePrepare = PdoGsb::$monPdo->prepare(
                 'SELECT comptable.id AS id, comptable.nom AS nom, '
-                . 'comptable.prenom AS prenom '
+                . 'comptable.prenom AS prenom, '
+                . 'comptable.mdp AS mdp '
                 . 'FROM comptable '
-                . 'WHERE comptable.login = :unLogin AND comptable.mdp = :unMdp'
+                . 'WHERE comptable.login = :unLogin'
             );
         }
 
         $requetePrepare->bindParam(':unLogin', $login, PDO::PARAM_STR);
-        $requetePrepare->bindParam(':unMdp', $mdp, PDO::PARAM_STR);
         $requetePrepare->execute();
-        return $requetePrepare->fetch();
+        $utilisateur = $requetePrepare->fetch();
+        if (password_verify($mdp, $utilisateur['mdp'])) {
+            // Pas besoin de garder le hash du mdp
+            unset($utilisateur['mdp']);
+            return $utilisateur;
+        } else {
+            return false;
+        }
+
     }
 
     /**

--- a/docker/database/gsb.sql
+++ b/docker/database/gsb.sql
@@ -173,7 +173,7 @@ CREATE TABLE IF NOT EXISTS `visiteur` (
   `nom` char(30) DEFAULT NULL,
   `prenom` char(30) DEFAULT NULL,
   `login` char(20) DEFAULT NULL,
-  `mdp` char(20) DEFAULT NULL,
+  `mdp` varchar(255) DEFAULT NULL,
   `adresse` char(30) DEFAULT NULL,
   `cp` char(5) DEFAULT NULL,
   `ville` char(30) DEFAULT NULL,
@@ -186,33 +186,33 @@ CREATE TABLE IF NOT EXISTS `visiteur` (
 --
 
 INSERT INTO `visiteur` (`id`, `nom`, `prenom`, `login`, `mdp`, `adresse`, `cp`, `ville`, `dateembauche`) VALUES
-('a131', 'Villechalane', 'Louis', 'lvillachane', 'jux7g', '8 rue des Charmes', '46000', 'Cahors', '2005-12-21'),
-('a17', 'Andre', 'David', 'dandre', 'oppg5', '1 rue Petit', '46200', 'Lalbenque', '1998-11-23'),
-('a55', 'Bedos', 'Christian', 'cbedos', 'gmhxd', '1 rue Peranud', '46250', 'Montcuq', '1995-01-12'),
-('a93', 'Tusseau', 'Louis', 'ltusseau', 'ktp3s', '22 rue des Ternes', '46123', 'Gramat', '2000-05-01'),
-('b13', 'Bentot', 'Pascal', 'pbentot', 'doyw1', '11 allée des Cerises', '46512', 'Bessines', '1992-07-09'),
-('b16', 'Bioret', 'Luc', 'lbioret', 'hrjfs', '1 Avenue gambetta', '46000', 'Cahors', '1998-05-11'),
-('b19', 'Bunisset', 'Francis', 'fbunisset', '4vbnd', '10 rue des Perles', '93100', 'Montreuil', '1987-10-21'),
-('b25', 'Bunisset', 'Denise', 'dbunisset', 's1y1r', '23 rue Manin', '75019', 'paris', '2010-12-05'),
-('b28', 'Cacheux', 'Bernard', 'bcacheux', 'uf7r3', '114 rue Blanche', '75017', 'Paris', '2009-11-12'),
-('b34', 'Cadic', 'Eric', 'ecadic', '6u8dc', '123 avenue de la République', '75011', 'Paris', '2008-09-23'),
-('b4', 'Charoze', 'Catherine', 'ccharoze', 'u817o', '100 rue Petit', '75019', 'Paris', '2005-11-12'),
-('b50', 'Clepkens', 'Christophe', 'cclepkens', 'bw1us', '12 allée des Anges', '93230', 'Romainville', '2003-08-11'),
-('b59', 'Cottin', 'Vincenne', 'vcottin', '2hoh9', '36 rue Des Roches', '93100', 'Monteuil', '2001-11-18'),
-('c14', 'Daburon', 'François', 'fdaburon', '7oqpv', '13 rue de Chanzy', '94000', 'Créteil', '2002-02-11'),
-('c3', 'De', 'Philippe', 'pde', 'gk9kx', '13 rue Barthes', '94000', 'Créteil', '2010-12-14'),
-('c54', 'Debelle', 'Michel', 'mdebelle', 'od5rt', '181 avenue Barbusse', '93210', 'Rosny', '2006-11-23'),
-('d13', 'Debelle', 'Jeanne', 'jdebelle', 'nvwqq', '134 allée des Joncs', '44000', 'Nantes', '2000-05-11'),
-('d51', 'Debroise', 'Michel', 'mdebroise', 'sghkb', '2 Bld Jourdain', '44000', 'Nantes', '2001-04-17'),
-('e22', 'Desmarquest', 'Nathalie', 'ndesmarquest', 'f1fob', '14 Place d Arc', '45000', 'Orléans', '2005-11-12'),
-('e24', 'Desnost', 'Pierre', 'pdesnost', '4k2o5', '16 avenue des Cèdres', '23200', 'Guéret', '2001-02-05'),
-('e39', 'Dudouit', 'Frédéric', 'fdudouit', '44im8', '18 rue de l église', '23120', 'GrandBourg', '2000-08-01'),
-('e49', 'Duncombe', 'Claude', 'cduncombe', 'qf77j', '19 rue de la tour', '23100', 'La souteraine', '1987-10-10'),
-('e5', 'Enault-Pascreau', 'Céline', 'cenault', 'y2qdu', '25 place de la gare', '23200', 'Gueret', '1995-09-01'),
-('e52', 'Eynde', 'Valérie', 'veynde', 'i7sn3', '3 Grand Place', '13015', 'Marseille', '1999-11-01'),
-('f21', 'Finck', 'Jacques', 'jfinck', 'mpb3t', '10 avenue du Prado', '13002', 'Marseille', '2001-11-10'),
-('f39', 'Frémont', 'Fernande', 'ffremont', 'xs5tq', '4 route de la mer', '13012', 'Allauh', '1998-10-01'),
-('f4', 'Gest', 'Alain', 'agest', 'dywvt', '30 avenue de la mer', '13025', 'Berre', '1985-11-01');
+('a131',	'Villechalane',	'Louis',	'lvillachane',	'$2y$10$paAj.kMCT7HYGrdxVzcGgez1Snr5LTP5xdqLP6Ug1SYqBF.dWCByC',	'8 rue des Charmes',	'46000',	'Cahors',	'2005-12-21'),
+('a17',	'Andre',	'David',	'dandre',	'$2y$10$.r.AT.wXAD4.nDtiyI0Bj.Ek.Sc8w.w19PMSF68eF0QHylDsuUmRy',	'1 rue Petit',	'46200',	'Lalbenque',	'1998-11-23'),
+('a55',	'Bedos',	'Christian',	'cbedos',	'$2y$10$9H/iuf/U1TxpZxy/vK5JDulaUvxar8cK1/smWcK/uIu6XzkXBMTu2',	'1 rue Peranud',	'46250',	'Montcuq',	'1995-01-12'),
+('a93',	'Tusseau',	'Louis',	'ltusseau',	'$2y$10$9FWK1Wef/40mGD7lYmPDsuBzNi8QJQ/NoJBwAvrW9WRuz/1r4yXI2',	'22 rue des Ternes',	'46123',	'Gramat',	'2000-05-01'),
+('b13',	'Bentot',	'Pascal',	'pbentot',	'$2y$10$UG5kPyub8at0xxFeRHeLbubMIHqFlsbiB9ojsCOvFrG28CJOvg0ba',	'11 allée des Cerises',	'46512',	'Bessines',	'1992-07-09'),
+('b16',	'Bioret',	'Luc',	'lbioret',	'$2y$10$gK.JNQagBjerZLuASkSxbOq2TApaf8tmX5Nlsrj9aU9ewl32Lg..m',	'1 Avenue gambetta',	'46000',	'Cahors',	'1998-05-11'),
+('b19',	'Bunisset',	'Francis',	'fbunisset',	'$2y$10$vePEXAr0IyCpXuVBq9c3VeBt62HktUIa8rquvTtf908JMSxVeuOc2',	'10 rue des Perles',	'93100',	'Montreuil',	'1987-10-21'),
+('b25',	'Bunisset',	'Denise',	'dbunisset',	'$2y$10$H7uIvTCNITIY3EkLm5vseO/Sv4Me9fZ6jWo4W6QqgzpjPfyudeSJ6',	'23 rue Manin',	'75019',	'paris',	'2010-12-05'),
+('b28',	'Cacheux',	'Bernard',	'bcacheux',	'$2y$10$ZBSv4q0iKYi045uvxKulJeFQJzfCZ8xGpEJNs19sBchzGi45mBDRi',	'114 rue Blanche',	'75017',	'Paris',	'2009-11-12'),
+('b34',	'Cadic',	'Eric',	'ecadic',	'$2y$10$r4ApLNnfBLCeviFjFTFPoOwRLd6HIpMyPGpDpw0DgxPj.FzN6u34S',	'123 avenue de la République',	'75011',	'Paris',	'2008-09-23'),
+('b4',	'Charoze',	'Catherine',	'ccharoze',	'$2y$10$Ctve82yWhcQ9m/7OQMtlceIVCcQx2lwWAPDaVe8ouoIg9NYw2gThK',	'100 rue Petit',	'75019',	'Paris',	'2005-11-12'),
+('b50',	'Clepkens',	'Christophe',	'cclepkens',	'$2y$10$wTaNIDc99ussjsFlndryrOZt5cJs/cv2I2IuW2QZuxctIZ2w9hpuC',	'12 allée des Anges',	'93230',	'Romainville',	'2003-08-11'),
+('b59',	'Cottin',	'Vincenne',	'vcottin',	'$2y$10$Kh8B2poU5n4zJ8YM0QUjl.89uyKvc372aD75r1QQjzwXxqbJCwpry',	'36 rue Des Roches',	'93100',	'Monteuil',	'2001-11-18'),
+('c14',	'Daburon',	'François',	'fdaburon',	'$2y$10$iNz.cZRdlP6yuGZR75EGaep/YHepffwy24pHJ2aetVvgg3K3tGuDS',	'13 rue de Chanzy',	'94000',	'Créteil',	'2002-02-11'),
+('c3',	'De',	'Philippe',	'pde',	'$2y$10$F.4VgYw.n5CWj/NWzvZpqeJ6M3UjOqpKezs3gHkXfFP693bKp7iGa',	'13 rue Barthes',	'94000',	'Créteil',	'2010-12-14'),
+('c54',	'Debelle',	'Michel',	'mdebelle',	'$2y$10$WMlAITr/Cu2SIJoqydZrie2fdzbLpngkL0CAUio1PtOXJxU6dcqV2',	'181 avenue Barbusse',	'93210',	'Rosny',	'2006-11-23'),
+('d13',	'Debelle',	'Jeanne',	'jdebelle',	'$2y$10$8UaheH6zZOrJNKBeQnkWWOUtOMNIhDwL9pJmg/TF89Q5eBnS4L1Wm',	'134 allée des Joncs',	'44000',	'Nantes',	'2000-05-11'),
+('d51',	'Debroise',	'Michel',	'mdebroise',	'$2y$10$Bb1tbgtbAANaWT5QyQvP5OtDT5C8EfodcWeNOxiYDITElrdoZiL2S',	'2 Bld Jourdain',	'44000',	'Nantes',	'2001-04-17'),
+('e22',	'Desmarquest',	'Nathalie',	'ndesmarquest',	'$2y$10$KsdPxiytFpehHETOLgLnSu/K3/b5AdGych.2mUTwtQ4/tT2amLhP.',	'14 Place d Arc',	'45000',	'Orléans',	'2005-11-12'),
+('e24',	'Desnost',	'Pierre',	'pdesnost',	'$2y$10$vEVoGWqZSiAGPs6w/.LymeHmxxyaUgKhb4WudKRqJNZ0OakY0X8OG',	'16 avenue des Cèdres',	'23200',	'Guéret',	'2001-02-05'),
+('e39',	'Dudouit',	'Frédéric',	'fdudouit',	'$2y$10$58RxUbH5XFvNdUxSVeSTD.pfaBMx7K7BxQsNelFWRCH6D/EqW.NUS',	'18 rue de l église',	'23120',	'GrandBourg',	'2000-08-01'),
+('e49',	'Duncombe',	'Claude',	'cduncombe',	'$2y$10$9pXwp21Y/A68WpGLJnitjuivgsXA0XJNhdrBQMfpELgqFiKCkM/ES',	'19 rue de la tour',	'23100',	'La souteraine',	'1987-10-10'),
+('e5',	'Enault-Pascreau',	'Céline',	'cenault',	'$2y$10$wc9wgD.eAbHbJofy3MHSK.LngpAaBwIf0eQ3UBm9X.22fanc5wCIG',	'25 place de la gare',	'23200',	'Gueret',	'1995-09-01'),
+('e52',	'Eynde',	'Valérie',	'veynde',	'$2y$10$8zNdsiW0/1ZS04Yno9mvne4casZh3ykU/hhPHUl7OCjrR.LfhalT2',	'3 Grand Place',	'13015',	'Marseille',	'1999-11-01'),
+('f21',	'Finck',	'Jacques',	'jfinck',	'$2y$10$zg5I8MCX/.QTXBCRKr3kjuFxkkrY7jGJgq5oUWgBaMoUA37.m7Wqu',	'10 avenue du Prado',	'13002',	'Marseille',	'2001-11-10'),
+('f39',	'Frémont',	'Fernande',	'ffremont',	'$2y$10$l7NjuAz/negOQV7P0mpd6.Kc3LXEu.A9M94dn48K/P9bNjcdCRTFC',	'4 route de la mer',	'13012',	'Allauh',	'1998-10-01'),
+('f4',	'Gest',	'Alain',	'agest',	'$2y$10$eRKsNCde1CfLl3mMK5lr9e2slSmF0/XbVqVNloVYZuDK0RJI1cpyG',	'30 avenue de la mer',	'13025',	'Berre',	'1985-11-01');
 
 -- --------------------------------------------------------
 
@@ -226,7 +226,7 @@ CREATE TABLE IF NOT EXISTS `comptable` (
   `nom` char(30) DEFAULT NULL,
   `prenom` char(30) DEFAULT NULL,
   `login` char(20) DEFAULT NULL,
-  `mdp` char(20) DEFAULT NULL,
+  `mdp` varchar(255) DEFAULT NULL,
   `adresse` char(30) DEFAULT NULL,
   `cp` char(5) DEFAULT NULL,
   `ville` char(30) DEFAULT NULL,
@@ -234,6 +234,8 @@ CREATE TABLE IF NOT EXISTS `comptable` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+INSERT INTO `comptable` (`id`, `nom`, `prenom`, `login`, `mdp`, `adresse`, `cp`, `ville`, `dateembauche`) VALUES
+('a131',	'',	'',	'admin',	'$2y$10$tAwGV5BFUxWD7.CjVw6zw.iJpJw6EtHl5RH8DVIeYihq62ryeG.je',	'',	'',	'',	'0000-00-00');
 --
 -- Constraints for dumped tables
 --


### PR DESCRIPTION
Le choix a été fait d'utiliser la fonction `password_hash` de php avec comme algorithme PASSWORD_DEFAULT  pour hasher les mots de passe car selon le[ manuel php](http://php.net/manual/fr/function.password-hash.php) :

> PASSWORD_DEFAULT - Utilisation de l'algorithme bcrypt (par défaut depuis PHP 5.5.0). Notez que cette constante est conçue pour changer dans le temps, au fur et à mesure que des algorithmes plus récents et plus forts sont ajoutés à PHP.

Cela permet plus de sécurité, néanmoins si une nouvelle version de php entraîne un changement d'algorithme, il faudra sans doute mettre à jour la base de données. 
